### PR TITLE
Build: Fix publishing of artifacts

### DIFF
--- a/example/build.sbt
+++ b/example/build.sbt
@@ -14,16 +14,12 @@ val SharedSettings = Seq(
   )
 )
 
-lazy val root = project.in(file("."))
+lazy val exampleRoot = project.in(file("."))
   .aggregate(js, jvm)
   .settings(SharedSettings: _*)
-  .settings(publishArtifact := false)
 
 lazy val example = crossProject.in(file("."))
   .settings(SharedSettings: _*)
-  .settings(
-    publishArtifact := false
-  )
   .jvmSettings(Revolver.settings: _*)
   .jvmSettings(
     libraryDependencies ++= Seq(


### PR DESCRIPTION
Example's `root` project collides with the eponymous project in the main build file.

`publishArtifact` doesn't need to be overridden.